### PR TITLE
FIX * fix slowness

### DIFF
--- a/plugin/manager.py
+++ b/plugin/manager.py
@@ -208,7 +208,7 @@ class RainbowBracketsViewManager(sublime_plugin.EventListener):
     def on_activated(self, view):
         self.check_view_load_executor(view)
 
-    def on_modified(self, view):
+    def on_modified_async(self, view):
         executor = self.view_executors.get(view.view_id, None)
         executor and executor.check_bracket_regions()
 


### PR DESCRIPTION
* fix extremely slow behavior on huge files (50 thousand lines, by eg)

The function on_modified it's called after every key is pressed, doing the sublime extremely slow on huge files with 30 or 50 thousand lines.

I change to on_modified_async to avoid this problem.